### PR TITLE
fix(css): Prevent styles leaking into embedded component previews

### DIFF
--- a/src/breeze/theme/base.css
+++ b/src/breeze/theme/base.css
@@ -798,7 +798,7 @@ p.db-page-headline + div {
   font-family: var(--db-font-family-body);
 }
 
-.markdown-section > :not(.code-preview) a {
+.markdown-section > :where(:not(.code-preview)) a {
   color: var(--db-content-link-color-text);
   font-weight: var(--db-content-link-font-weight);
   text-decoration: var(--db-content-link-text-decoration);
@@ -806,7 +806,7 @@ p.db-page-headline + div {
 }
 
 .markdown-section > a:hover,
-.markdown-section > :not(.code-preview) a:hover {
+.markdown-section > :where(:not(.code-preview)) a:hover {
   color: var(--db-content-link-color-text-hover);
   text-decoration: var(--db-content-link-text-decoration-hover);
   background-color: var(--db-content-link-color-background-hover);
@@ -827,7 +827,7 @@ p.db-page-headline + div {
 }
 
 .markdown-section > code,
-.markdown-section > :not(.code-preview) code,
+.markdown-section > :where(:not(.code-preview)) code,
 .controls__inputs code {
   display: inline-block;
   margin: var(--db-content-code-margin);
@@ -858,6 +858,7 @@ p.db-page-headline + div {
   background-color: transparent;
   border: none;
   tab-size: var(--db-content-code-block-tab-size);
+  font-family: var(--db-content-code-font-family);
   font-size: var(--db-content-code-block-font-size);
   line-height: var(--db-content-code-block-line-height);
 }

--- a/src/breeze/theme/base.css
+++ b/src/breeze/theme/base.css
@@ -31,9 +31,15 @@ body {
   }
 }
 
-a:focus-visible,
-button:focus-visible,
-[role="slider"]:focus-visible {
+/* NB: :where() to knock down specificity */
+:not(:where(
+  .code-preview__scrollable,
+  .code-preview__scrollable *
+)):is(
+  a,
+  button,
+  [role="slider"]
+):focus-visible {
   outline: 2px solid var(--db-color-focus-visible);
   outline-offset: 3px;
 }
@@ -758,16 +764,18 @@ p.db-page-headline + div {
   line-height: var(--db-content-line-height);
 }
 
-.markdown-section li {
+.markdown-section > li,
+.markdown-section > :not(.code-preview) li {
   margin-bottom: var(--db-content-list-margin-bottom);
 }
 
-.markdown-section li:last-child {
+.markdown-section > li:last-child,
+.markdown-section > :not(.code-preview) li:last-child {
   margin-bottom: 0;
 }
 
-.markdown-section li ul,
-.markdown-section li ol {
+.markdown-section > li :is(ol, ul),
+.markdown-section > :not(.code-preview) li :is(ol, ul) {
   margin: var(--db-content-list-margin-bottom) 0;
 }
 
@@ -786,24 +794,26 @@ p.db-page-headline + div {
   color: var(--db-content-list-bullet-color-fill);
 }
 
-.markdown-section button {
+.markdown-section > :not(.code-preview) button {
   font-family: var(--db-font-family-body);
 }
 
-.markdown-section a {
+.markdown-section > :not(.code-preview) a {
   color: var(--db-content-link-color-text);
   font-weight: var(--db-content-link-font-weight);
   text-decoration: var(--db-content-link-text-decoration);
   transition: var(--db-content-link-transition);
 }
 
-.markdown-section a:hover {
+.markdown-section > a:hover,
+.markdown-section > :not(.code-preview) a:hover {
   color: var(--db-content-link-color-text-hover);
   text-decoration: var(--db-content-link-text-decoration-hover);
   background-color: var(--db-content-link-color-background-hover);
 }
 
-.markdown-section a[rel="noopener"]:not(.edit-on-github) {
+.markdown-section > a[rel="noopener"]:not(.edit-on-github),
+.markdown-section > :not(.code-preview) a[rel="noopener"] {
   background-position: right calc(100% - 1px);
   background-repeat: no-repeat;
   background-image: var(--db-icon-arrow-up-right);
@@ -811,11 +821,13 @@ p.db-page-headline + div {
   padding-right: 1rem;
 }
 
-.markdown-section a[rel="noopener"]:not(.edit-on-github):hover {
+.markdown-section > a[rel="noopener"]:not(.edit-on-github):hover,
+.markdown-section > :not(.code-preview) a[rel="noopener"]:hover {
   background-image: var(--db-icon-arrow-up-right-hover);
 }
 
-.markdown-section code,
+.markdown-section > code,
+.markdown-section > :not(.code-preview) code,
 .controls__inputs code {
   display: inline-block;
   margin: var(--db-content-code-margin);
@@ -828,13 +840,17 @@ p.db-page-headline + div {
   line-height: var(--db-content-code-line-height);
 }
 
-.markdown-section pre {
+.markdown-section > pre,
+.markdown-section > :not(.code-preview) pre,
+.code-preview__source pre {
   position: relative;
   background-color: var(--db-content-code-block-color-background);
   border-radius: var(--db-content-code-block-border-radius);
 }
 
-.markdown-section pre code {
+.markdown-section > pre code,
+.markdown-section > :not(.code-preview) pre code,
+.code-preview__source pre code {
   display: block;
   margin: var(--db-content-code-block-margin);
   padding: var(--db-content-code-block-padding);
@@ -846,7 +862,8 @@ p.db-page-headline + div {
   line-height: var(--db-content-code-block-line-height);
 }
 
-.markdown-section kbd {
+.markdown-section > kbd,
+.markdown-section > :not(.code-preview) kbd {
   display: inline-block;
   margin-bottom: 0.1875rem;
   padding: 0.1875rem 0.3125rem;

--- a/src/breeze/theme/plugins/web-component-viewer.css
+++ b/src/breeze/theme/plugins/web-component-viewer.css
@@ -13,6 +13,35 @@
   width: calc(100% - 1.5rem);
   padding: 2rem;
   overflow: auto;
+  /* firewall all heritable properties */
+  border-collapse: revert;
+  border-spacing: revert;
+  caption-side: revert;
+  color: revert;
+  cursor: revert;
+  direction: revert;
+  empty-cells: revert;
+  font-family: revert;
+  font-size: revert;
+  font-style: revert;
+  font-variant: revert;
+  font-weight: revert;
+  font: revert;
+  letter-spacing: revert;
+  line-height: revert;
+  list-style-image: revert;
+  list-style-position: revert;
+  list-style-type: revert;
+  list-style: revert;
+  orphans: revert;
+  quotes: revert;
+  text-align: revert;
+  text-indent: revert;
+  text-transform: revert;
+  visibility: revert;
+  white-space: revert;
+  widows: revert;
+  word-spacing: revert;
 }
 
 .code-preview__resizer {

--- a/src/breeze/theme/plugins/web-component-viewer.css
+++ b/src/breeze/theme/plugins/web-component-viewer.css
@@ -13,35 +13,6 @@
   width: calc(100% - 1.5rem);
   padding: 2rem;
   overflow: auto;
-  /* firewall all heritable properties */
-  border-collapse: revert;
-  border-spacing: revert;
-  caption-side: revert;
-  color: revert;
-  cursor: revert;
-  direction: revert;
-  empty-cells: revert;
-  font-family: revert;
-  font-size: revert;
-  font-style: revert;
-  font-variant: revert;
-  font-weight: revert;
-  font: revert;
-  letter-spacing: revert;
-  line-height: revert;
-  list-style-image: revert;
-  list-style-position: revert;
-  list-style-type: revert;
-  list-style: revert;
-  orphans: revert;
-  quotes: revert;
-  text-align: revert;
-  text-indent: revert;
-  text-transform: revert;
-  visibility: revert;
-  white-space: revert;
-  widows: revert;
-  word-spacing: revert;
 }
 
 .code-preview__resizer {


### PR DESCRIPTION
In order to preview components 1) conveniently embedded in documentation, and 2) in as representative a presentation as possible, I want to be able to apply certain stylesheets (such as themes)—perhaps use them to style the documentation to match—but I don't want styles intended only for the docs' presentation to affect the component previews (embedded and elsewhere).

Until `revert-layer` is widely supported, we don't have an easy way to selectively roll back applied stylesheets. And in the case of embedded component previews, simply namespacing styles to `.markdown-section`, for example, will still target light-DOM elements in the embeds. While heavy and verbose, any rules targeting the markdown content need to conscientiously avoid catching any preview containers. Fortunately, the section's structure is predictable enough to not have to anticipate _every_ arbitrary nesting order and depth.

That said, there is global treatment to some clickable elements which resulted in a gnarly work-around [here](https://github.com/LipGlossary/docsify-breeze/blob/53a7dd26c433a68870fd344a19cf06ca03eadc4f/src/breeze/theme/base.css#L35-L42). As a sanity-check, the screenshot below demos some buttons peppered around the document, and we can see that the ones outside `.code-preview__scrollable` received the Breeze treatment, while the one in the preview canvas only shows the lighter-weight user origin style (representative of a theme or something in that realm of use cases). (The actual component's button is, of course, shielded from both in the shadow tree.)

<img width="1111" alt="Screen Shot 2023-04-06 at 14 48 57" src="https://user-images.githubusercontent.com/1580086/230500302-678fd05f-2a36-4982-b42d-7017737ad28d.png">

-----

~~As a bonus, I `revert`ed all heritable properties on that preview container to give us a bit cleaner slate. However, this does wipe out general theme styles that would be applied to `:root`/`body`/`.ds-retro`. Because components ought to be styled agnostically to these styles, this shouldn't break anything in "the wild", but it _is_ misleading and could cause visual regression of placeholder light DOM elements in examples. I think the sanest thing to do here is advise folks to scope theme styles to a class and amend the `theme-switcher` plugin to apply that class to both the root/body and each preview container (such that it will be heavier than the reversion).~~

Edit: The above change is not that important, tangentially related, and causes too much hassle right now. I pulled it and we can think about it later.