### PR TITLE
Fixes tip and warn helper styling

### DIFF
--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -1,7 +1,5 @@
 # Button
 
-!> This component relies on light DOM styling. Styles must be manually imported and applied if rendering this component inside the shadow DOM of another component.
-
 ```html preview expanded controls default
 <ds-button>Button</ds-button>
 ```

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -1,5 +1,7 @@
 # Button
 
+!> This component relies on light DOM styling. Styles must be manually imported and applied if rendering this component inside the shadow DOM of another component.
+
 ```html preview expanded controls default
 <ds-button>Button</ds-button>
 ```

--- a/src/breeze/theme/base.css
+++ b/src/breeze/theme/base.css
@@ -32,14 +32,11 @@ body {
 }
 
 /* NB: :where() to knock down specificity */
-:not(:where(
-  .code-preview__scrollable,
-  .code-preview__scrollable *
-)):is(
-  a,
-  button,
-  [role="slider"]
-):focus-visible {
+:not(:where(.code-preview__scrollable, .code-preview__scrollable *)):is(
+    a,
+    button,
+    [role="slider"]
+  ):focus-visible {
   outline: 2px solid var(--db-color-focus-visible);
   outline-offset: 3px;
 }
@@ -889,17 +886,17 @@ p.db-page-headline + div {
   padding: var(--db-content-tip-padding);
 }
 
-.markdown-section p.tip {
+.markdown-section p.warn {
   background-color: var(--db-content-tip-color-background);
   border-left: var(--db-content-tip-border-left);
 }
 
-.markdown-section p.warn {
+.markdown-section p.tip {
   background-color: var(--db-content-tip-warn-color-background);
   border-left: var(--db-content-tip-warn-border-left);
 }
 
-.markdown-section p.warn::before {
+.markdown-section p.tip::before {
   content: "!";
   position: absolute;
   top: 1rem;


### PR DESCRIPTION
For some reason these class names are flipped in Docsify. `!>` results in a `.tip` class and `?>` results in a `.warn` class.